### PR TITLE
Typing errors on main.go

### DIFF
--- a/cmd/killgrave/main.go
+++ b/cmd/killgrave/main.go
@@ -18,10 +18,10 @@ var (
 
 func main() {
 	host := flag.String("host", "localhost", "if you run your server on a different host")
-	port := flag.Int("port", 3000, "por to run the server")
+	port := flag.Int("port", 3000, "port to run the server")
 	imposters := flag.String("imposters", "imposters", "directory where your imposters are saved")
 	v := flag.Bool("version", false, "show the version of the application")
-	c := flag.String("config", "", "path with configuration file")
+	c := flag.String("config", "", "path with the configuration file")
 
 	flag.Parse()
 


### PR DESCRIPTION
Some typing errors on the `main.go` file