### PR TITLE
.gitignore improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,9 +10,8 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+coverage.txt
 
 imposters
-schemas
 
 !internal/test/testdata/imposters/
-!internal/test/testdata/imposters/schemas/


### PR DESCRIPTION
I've deleted the `schemas`-related items because it is no longer needed since one of the last updates.

In addition, I've added the `coverage.txt` file, which corresponds to the coverage tool output, as the items that satisfy `*.out`.

Thanks!