### PR TITLE
Configuration file improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,11 @@ cors:
   allow_credentials: true
 ```
 
-The parameter `cors` is optional and his options can be empty array, the other options `imposters_path`, `port`, `host` are mandatory.
+Historically, the options `imposters_path`, `port`, `host` were mandatory when using a configuration file.
+
+However, since last versions, they are no longer needed, so you can simply override those options you want to.
+
+The option `cors` still being optional and his options can be an empty array,
 
 If you want more information about the CORS options, visit the [CORS section](#CORS).
 


### PR DESCRIPTION
Hi,

Here some configuration file improvements:

- On the one hand, with these changes it is not longer needed to define all the parameters in the configuration file. So, now you can simple use the configuration file to override only the `port` or the `host` options.

- On the other hand, these changes contain the fix for the issue #20, to make the paths on the configuration file relative to it, what has much more sense. 

Thanks!