### PR TITLE
26-remove-pkg/errors-lib

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,15 +1,5 @@
 version: 2.1
 jobs:
-  build-go1_11_6:
-    docker:
-      - image: circleci/golang:1.11.6
-        environment:
-          GO111MODULE: "on"
-    working_directory: /go/src/github.com/friendsofgo/killgrave
-    steps:
-      - checkout
-      - run: go test -v -race ./...
-      - run: go build -race cmd/killgrave/main.go
   build-go1_13_1:
     docker:
       - image: circleci/golang:1.13.1
@@ -18,16 +8,6 @@ jobs:
       - checkout
       - run: go test -v -race ./...
       - run: go build -race cmd/killgrave/main.go
-  build-go1_12_9:
-    docker:
-      - image: circleci/golang:1.12.9
-        environment:
-          GO111MODULE: "on"
-    working_directory: /go/src/github.com/friendsofgo/killgrave
-    steps:
-      - checkout
-      - run: go test -v -race ./...
-      - run: go build -race cmd/killgrave/main.go  
   build-go_latest:
     docker:
       - image: circleci/golang:latest
@@ -58,8 +38,6 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - build-go1_11_6
-      - build-go1_12_9
       - build-go1_13_1
       - build-go_latest
       - coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## v0.4.0 (TBD)
 * The config file option load the imposters path relative on where the config file is
 * Upgrade Killgrave to go1.13
+* Remove use of github.com/pkg/errors in favor to standard errors package
+* Remove backward compatibility with previous versions to go 1.13
 
 ## v0.3.3 (2019/05/11)
 

--- a/internal/config.go
+++ b/internal/config.go
@@ -1,11 +1,11 @@
 package killgrave
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
 
-	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 )
 
@@ -55,13 +55,13 @@ func WithConfigFile(cfgPath string) ConfigOpt {
 
 		configFile, err := os.Open(cfgPath)
 		if err != nil {
-			return errors.Wrapf(err, "error trying to read config file: %s, using default configuration instead", cfgPath)
+			return fmt.Errorf("%w: error trying to read config file: %s, using default configuration instead", err, cfgPath)
 		}
 		defer configFile.Close()
 
 		bytes, _ := ioutil.ReadAll(configFile)
 		if err := yaml.Unmarshal(bytes, cfg); err != nil {
-			return errors.Wrapf(err, "error while unmarshall configFile file %s, using default configuration instead", cfgPath)
+			return fmt.Errorf("%w: error while unmarshall configFile file %s, using default configuration instead", err, cfgPath)
 		}
 
 		cfg.ImpostersPath = path.Join(path.Dir(cfgPath), cfg.ImpostersPath)

--- a/internal/config_test.go
+++ b/internal/config_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/pkg/errors"
+	"errors"
 )
 
 func TestNewConfig(t *testing.T) {

--- a/internal/imposter.go
+++ b/internal/imposter.go
@@ -1,12 +1,11 @@
 package killgrave
 
 import (
+	"fmt"
 	"os"
 	"path"
 	"path/filepath"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 const imposterExtension = ".imp.json"
@@ -43,7 +42,7 @@ type Response struct {
 func findImposters(impostersDirectory string, imposterFileCh chan string) error {
 	err := filepath.Walk(impostersDirectory, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
-			return errors.Wrap(err, "error finding imposters")
+			return fmt.Errorf("%w: error finding imposters", err)
 		}
 		if !info.IsDir() && strings.LastIndex(info.Name(), imposterExtension) != -1 {
 			imposterFileCh <- path

--- a/internal/route_matchers.go
+++ b/internal/route_matchers.go
@@ -8,8 +8,9 @@ import (
 	"net/http"
 	"os"
 
+	"errors"
+
 	"github.com/gorilla/mux"
-	"github.com/pkg/errors"
 	"github.com/xeipuuv/gojsonschema"
 )
 
@@ -41,12 +42,12 @@ func validateSchema(imposter Imposter, req *http.Request) error {
 
 	schemaFile := imposter.CalculateFilePath(*imposter.Request.SchemaFile)
 	if _, err := os.Stat(schemaFile); os.IsNotExist(err) {
-		return errors.Wrapf(err, "the schema file %s not found", schemaFile)
+		return fmt.Errorf("%w: the schema file %s not found", err, schemaFile)
 	}
 
 	b, err := ioutil.ReadAll(req.Body)
 	if err != nil {
-		return errors.Wrapf(err, "impossible read the request body")
+		return fmt.Errorf("%w: impossible read the request body", err)
 	}
 
 	contentBody := string(b)
@@ -61,7 +62,7 @@ func validateSchema(imposter Imposter, req *http.Request) error {
 
 	res, err := gojsonschema.Validate(schema, document)
 	if err != nil {
-		return errors.Wrap(err, "error validating the json schema")
+		return fmt.Errorf("%w: error validating the json schema", err)
 	}
 
 	if !res.Valid() {

--- a/internal/route_matchers_test.go
+++ b/internal/route_matchers_test.go
@@ -6,8 +6,9 @@ import (
 	"net/http"
 	"testing"
 
+	"errors"
+
 	"github.com/gorilla/mux"
-	"github.com/pkg/errors"
 )
 
 func TestMatcherBySchema(t *testing.T) {

--- a/internal/server.go
+++ b/internal/server.go
@@ -2,6 +2,7 @@ package killgrave
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
@@ -9,7 +10,6 @@ import (
 
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
-	"github.com/pkg/errors"
 )
 
 var (
@@ -65,7 +65,7 @@ func (s *Server) AccessControl(config ConfigCORS) (h []handlers.CORSOption) {
 // handlers for each imposter
 func (s *Server) Build() error {
 	if _, err := os.Stat(s.impostersPath); os.IsNotExist(err) {
-		return errors.Wrapf(err, "the directory %s doesn't exists", s.impostersPath)
+		return fmt.Errorf("%w: the directory %s doesn't exists", err, s.impostersPath)
 	}
 	var imposterFileCh = make(chan string)
 	var done = make(chan bool)
@@ -120,7 +120,7 @@ func (s *Server) unmarshalImposters(imposterFileName string, imposters *[]Impost
 
 	bytes, _ := ioutil.ReadAll(imposterFile)
 	if err := json.Unmarshal(bytes, imposters); err != nil {
-		return errors.Wrapf(err, "error while unmarshall imposter file %s", imposterFileName)
+		return fmt.Errorf("%w: error while unmarshall imposter file %s", err, imposterFileName)
 	}
 	return nil
 }

--- a/internal/server_test.go
+++ b/internal/server_test.go
@@ -3,8 +3,9 @@ package killgrave
 import (
 	"testing"
 
+	"errors"
+
 	"github.com/gorilla/mux"
-	"github.com/pkg/errors"
 )
 
 func TestRunServer(t *testing.T) {


### PR DESCRIPTION
Using '%w' for error wrapping [Documentation](https://golang.org/doc/go1.13#error_wrapping)
Fixes #26 