### PR TITLE
Add delay option to response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Remove backward compatibility with previous versions to go 1.13
 * Add `-watcher` flag to reload the server with any changes on `imposters` folder
 * Fix searching imposter files mechanism
+* Allow to add latency to responses
 
 ## v0.3.3 (2019/05/11)
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+[![CircleCI](https://circleci.com/gh/friendsofgo/killgrave/tree/master.svg?style=svg)](https://circleci.com/gh/friendsofgo/killgrave/tree/master)
+[![Version](https://img.shields.io/github/release/friendsofgo/killgrave.svg?style=flat-square)](https://github.com/friendsofgo/killgrave/releases/latest)
+[![codecov](https://codecov.io/gh/friendsofgo/killgrave/branch/master/graph/badge.svg)](https://codecov.io/gh/friendsofgo/killgrave)
+[![Go Report Card](https://goreportcard.com/badge/github.com/friendsofgo/killgrave)](https://goreportcard.com/report/github.com/friendsofgo/killgrave)
+[![FriendsOfGo](https://img.shields.io/badge/powered%20by-Friends%20of%20Go-73D7E2.svg)](https://friendsofgo.tech)
 
 </br>
 <a href="https://www.buymeacoffee.com/friendsofgo" target="_blank"><img src="https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png" alt="Buy Me A Coffee" style="height: auto !important;width: 100px !important;" ></a>
@@ -104,6 +109,10 @@ However, since last versions, they are no longer needed, so you can simply overr
 Furthermore the `imposters_path` option in previous version towards reference to the path where the app was launched, but
 in the last version the `imposters_path` option is relative on where the config file is.
 
+The `delay` option is a time that server waits before response. This can help simulate network issues, or server high load. You must write delay as string with postfix indicating time unit (see [this](https://golang.org/pkg/time/#ParseDuration) for more info about actual format). Also you can specify minimum and maximum delays using separator ':', server respond delay will be choosen at random between this values.
+
+Default value is no delay at all.
+
 The option `cors` still being optional and his options can be an empty array,
 
 If you want more information about the CORS options, visit the [CORS section](#CORS).
@@ -135,7 +144,8 @@ imposters/create_gopher.imp.json
             "headers": {
                 "Content-Type": "application/json"
             },
-            "body": "{\"error\": \"Server error ocurred\"}"
+            "body": "{\"error\": \"Server error ocurred\"}",
+            "delay": "1s:5s"
         }
     },
     {
@@ -237,8 +247,6 @@ curl --header "Content-Type: application/json" \
   http://localhost:3000/gophers
 ```
 
-
-
 ## CORS
 
 If you want to use `killgrave` on your client application you must consider to configure correctly all about CORS, thus we offer the possibility to configure as you need through a config file.
@@ -270,21 +278,6 @@ In the CORS section of the file you can find the next options:
 - **allow_credentials** (boolean)
   
   Represent the **Access-Control-Allow-Credentials header** you must indicate if true or false
-  
-## Imposter configuration file 
-Imposter file consists of JSON array of imposters. Each imposter can have two sections: `request` that describes request and `response`.
-
-### Request section
-
-### Response section
-Response section describes response that imposter server will send on matching request. Response can have next fields:
-
-#### delay
-Time that server waits before response. This can help simulate network issues, or server high load. You must write delay as string with postfix indicating time unit (see [this](https://golang.org/pkg/time/#ParseDuration) for more info about actual format). Also you can specify minimum and maximum delays using separator ':', server respond delay will be choosen at random between this values.
-```
-"delay": "1s:3m"
-```
-Default value is no delay at all.
 
 ## Features
 * Imposters created in json

--- a/README.md
+++ b/README.md
@@ -1,8 +1,3 @@
-[![CircleCI](https://circleci.com/gh/friendsofgo/killgrave/tree/master.svg?style=svg)](https://circleci.com/gh/friendsofgo/killgrave/tree/master)
-[![Version](https://img.shields.io/github/release/friendsofgo/killgrave.svg?style=flat-square)](https://github.com/friendsofgo/killgrave/releases/latest)
-[![codecov](https://codecov.io/gh/friendsofgo/killgrave/branch/master/graph/badge.svg)](https://codecov.io/gh/friendsofgo/killgrave)
-[![Go Report Card](https://goreportcard.com/badge/github.com/friendsofgo/killgrave)](https://goreportcard.com/report/github.com/friendsofgo/killgrave)
-[![FriendsOfGo](https://img.shields.io/badge/powered%20by-Friends%20of%20Go-73D7E2.svg)](https://friendsofgo.tech)
 
 </br>
 <a href="https://www.buymeacoffee.com/friendsofgo" target="_blank"><img src="https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png" alt="Buy Me A Coffee" style="height: auto !important;width: 100px !important;" ></a>
@@ -242,6 +237,8 @@ curl --header "Content-Type: application/json" \
   http://localhost:3000/gophers
 ```
 
+
+
 ## CORS
 
 If you want to use `killgrave` on your client application you must consider to configure correctly all about CORS, thus we offer the possibility to configure as you need through a config file.
@@ -273,6 +270,21 @@ In the CORS section of the file you can find the next options:
 - **allow_credentials** (boolean)
   
   Represent the **Access-Control-Allow-Credentials header** you must indicate if true or false
+  
+## Imposter configuration file 
+Imposter file consists of JSON array of imposters. Each imposter can have two sections: `request` that describes request and `response`.
+
+### Request section
+
+### Response section
+Response section describes response that imposter server will send on matching request. Response can have next fields:
+
+#### delay
+Time that server waits before response. This can help simulate network issues, or server high load. You must write delay as string with postfix indicating time unit (see [this](https://golang.org/pkg/time/#ParseDuration) for more info about actual format). Also you can specify minimum and maximum delays using separator ':', server respond delay will be choosen at random between this values.
+```
+"delay": "1s:3m"
+```
+Default value is no delay at all.
 
 ## Features
 * Imposters created in json
@@ -292,6 +304,7 @@ In the CORS section of the file you can find the next options:
 * Allow write multiple imposters by file
 * Run mock server with predefined configuration with config yaml file
 * Configure your CORS server options
+* Simulate network issues and server high loads with imposter repsonse delay
 
 ## Next Features
 - [ ] Proxy server

--- a/internal/server/http/handler.go
+++ b/internal/server/http/handler.go
@@ -5,11 +5,13 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"time"
 )
 
 // ImposterHandler create specific handler for the received imposter
 func ImposterHandler(imposter Imposter) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(imposter.Response.Delay.Delay())
 		writeHeaders(imposter, w)
 		w.WriteHeader(imposter.Response.Status)
 		writeBody(imposter, w)

--- a/internal/server/http/handler.go
+++ b/internal/server/http/handler.go
@@ -11,9 +11,9 @@ import (
 // ImposterHandler create specific handler for the received imposter
 func ImposterHandler(imposter Imposter) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-if imposter.Delay() > 0 {
-  time.Sleep(imposter.Delay()
-}
+		if imposter.Delay() > 0 {
+			time.Sleep(imposter.Delay())
+		}
 		writeHeaders(imposter, w)
 		w.WriteHeader(imposter.Response.Status)
 		writeBody(imposter, w)

--- a/internal/server/http/handler.go
+++ b/internal/server/http/handler.go
@@ -11,7 +11,9 @@ import (
 // ImposterHandler create specific handler for the received imposter
 func ImposterHandler(imposter Imposter) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(imposter.GetDelay())
+if imposter.Delay() > 0 {
+  time.Sleep(imposter.Delay()
+}
 		writeHeaders(imposter, w)
 		w.WriteHeader(imposter.Response.Status)
 		writeBody(imposter, w)

--- a/internal/server/http/handler.go
+++ b/internal/server/http/handler.go
@@ -11,7 +11,7 @@ import (
 // ImposterHandler create specific handler for the received imposter
 func ImposterHandler(imposter Imposter) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(imposter.Response.Delay.Delay())
+		time.Sleep(imposter.Response.GetDelay())
 		writeHeaders(imposter, w)
 		w.WriteHeader(imposter.Response.Status)
 		writeBody(imposter, w)

--- a/internal/server/http/handler.go
+++ b/internal/server/http/handler.go
@@ -11,7 +11,7 @@ import (
 // ImposterHandler create specific handler for the received imposter
 func ImposterHandler(imposter Imposter) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(imposter.Response.GetDelay())
+		time.Sleep(imposter.GetDelay())
 		writeHeaders(imposter, w)
 		w.WriteHeader(imposter.Response.Status)
 		writeBody(imposter, w)

--- a/internal/server/http/imposter.go
+++ b/internal/server/http/imposter.go
@@ -18,6 +18,11 @@ type Imposter struct {
 	Response Response `json:"response"`
 }
 
+// GetDelay returns delay for response that user can specify in imposter config
+func (i *Imposter) GetDelay() time.Duration {
+	return i.Response.Delay.Delay()
+}
+
 // CalculateFilePath calculate file path based on basePath of imposter directory
 func (i *Imposter) CalculateFilePath(filePath string) string {
 	return path.Join(i.BasePath, filePath)
@@ -39,10 +44,6 @@ type Response struct {
 	BodyFile *string            `json:"bodyFile"`
 	Headers  *map[string]string `json:"headers"`
 	Delay    ResponseDelay      `json:"delay"`
-}
-
-func (r *Response) GetDelay() time.Duration {
-	return r.Delay.Delay()
 }
 
 func findImposters(impostersDirectory string, imposterFileCh chan string) error {

--- a/internal/server/http/imposter.go
+++ b/internal/server/http/imposter.go
@@ -18,7 +18,7 @@ type Imposter struct {
 	Response Response `json:"response"`
 }
 
-// GetDelay returns delay for response that user can specify in imposter config
+// Delay returns delay for response that user can specify in imposter config
 func (i *Imposter) Delay() time.Duration {
 	return i.Response.Delay.Delay()
 }

--- a/internal/server/http/imposter.go
+++ b/internal/server/http/imposter.go
@@ -37,6 +37,7 @@ type Response struct {
 	Body     string             `json:"body"`
 	BodyFile *string            `json:"bodyFile"`
 	Headers  *map[string]string `json:"headers"`
+	Delay    ResponseDelay      `json:"delay"`
 }
 
 func findImposters(impostersDirectory string, imposterFileCh chan string) error {

--- a/internal/server/http/imposter.go
+++ b/internal/server/http/imposter.go
@@ -6,6 +6,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 const imposterExtension = ".imp.json"
@@ -38,6 +39,10 @@ type Response struct {
 	BodyFile *string            `json:"bodyFile"`
 	Headers  *map[string]string `json:"headers"`
 	Delay    ResponseDelay      `json:"delay"`
+}
+
+func (r *Response) GetDelay() time.Duration {
+	return r.Delay.Delay()
 }
 
 func findImposters(impostersDirectory string, imposterFileCh chan string) error {

--- a/internal/server/http/imposter.go
+++ b/internal/server/http/imposter.go
@@ -19,7 +19,7 @@ type Imposter struct {
 }
 
 // GetDelay returns delay for response that user can specify in imposter config
-func (i *Imposter) GetDelay() time.Duration {
+func (i *Imposter) Delay() time.Duration {
 	return i.Response.Delay.Delay()
 }
 

--- a/internal/server/http/response_delay.go
+++ b/internal/server/http/response_delay.go
@@ -52,7 +52,7 @@ func (d *ResponseDelay) UnmarshalJSON(data []byte) error {
 		offset = int64(maxDelay) - int64(minDelay)
 	}
 	if offset < 0 {
-		return errors.New("second time point is before first time point")
+		return errors.New("second value should be greater than the first one")
 	}
 	d.delay = int64(minDelay)
 	d.offset = offset

--- a/internal/server/http/response_delay_test.go
+++ b/internal/server/http/response_delay_test.go
@@ -1,0 +1,112 @@
+package http
+
+import (
+	"encoding/json"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestResponceDelayUnmarshal(t *testing.T) {
+	testCases := map[string]struct {
+		input string
+		delay ResponseDelay
+		err   error
+	}{
+		"Invalid type": {
+			input: `23`,
+			err:   errors.New("error"),
+		},
+		"Valid empty delay": {
+			input: `""`,
+			delay: ResponseDelay{0, 0},
+		},
+		"Valid fixed delay": {
+			input: `"1s"`,
+			delay: getDelay(t, "1s", "0s"),
+		},
+		"Fixed delay without unit suffix": {
+			input: `"13"`,
+			err:   errors.New("error"),
+		},
+		"Valid range delay": {
+			input: `"2s:7s"`,
+			delay: getDelay(t, "2s", "5s"),
+		},
+		"Range delay with incorrect delimiter": {
+			input: `"1m-3s"`,
+			err:   errors.New("error"),
+		},
+		"Range delay with extra field": {
+			input: `"1m:3s:5s"`,
+			err:   errors.New("error"),
+		},
+		"Range delay where second point is before first": {
+			input: `"5s:1s"`,
+			err:   errors.New("error"),
+		},
+		"Range delay where second point invalid": {
+			input: `"5s:1"`,
+			err:   errors.New("error"),
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			var delay ResponseDelay
+			err := json.Unmarshal([]byte(tc.input), &delay)
+			if err != nil && tc.err == nil {
+				t.Fatalf("not expected any erros and got: %v", err)
+			}
+
+			if err == nil && tc.err != nil {
+				t.Fatalf("expected an error and got nil")
+			}
+			if !reflect.DeepEqual(tc.delay, delay) {
+				t.Fatalf("expected: %v, got: %v", tc.delay, delay)
+			}
+
+		})
+	}
+}
+
+func TestResponceDelayDelay(t *testing.T) {
+	testCases := map[string]struct {
+		delay ResponseDelay
+	}{
+		"Empty delay": {
+			delay: ResponseDelay{0, 0},
+		},
+		"Fixed delay": {
+			delay: getDelay(t, "2s", "0s"),
+		},
+		"Range delay": {
+			delay: getDelay(t, "2s", "5s"),
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			min := tc.delay.delay
+			max := min + tc.delay.offset
+			for i := 0; i < 10; i++ {
+				delay := int64(tc.delay.Delay())
+				if delay < min || delay > max {
+					t.Errorf("delay should be in interval [%d, %d] but actual value is: %d", min, max, delay)
+				}
+			}
+
+		})
+	}
+}
+
+func getDelay(t *testing.T, min string, offset string) ResponseDelay {
+	minDuration, err := time.ParseDuration(min)
+	if err != nil {
+		t.Fatal("ParseDuration min fail: ", err)
+	}
+	offsetDuration, err := time.ParseDuration(offset)
+	if err != nil {
+		t.Fatal("ParseDuration max fail: ", err)
+	}
+	return ResponseDelay{int64(minDuration), int64(offsetDuration)}
+}

--- a/internal/server/http/response_delay_test.go
+++ b/internal/server/http/response_delay_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-func TestResponceDelayUnmarshal(t *testing.T) {
+func TestResponseDelayUnmarshal(t *testing.T) {
 	testCases := map[string]struct {
 		input string
 		delay ResponseDelay
@@ -56,7 +56,7 @@ func TestResponceDelayUnmarshal(t *testing.T) {
 			var delay ResponseDelay
 			err := json.Unmarshal([]byte(tc.input), &delay)
 			if err != nil && tc.err == nil {
-				t.Fatalf("not expected any erros and got: %v", err)
+				t.Fatalf("not expected any error and got: %v", err)
 			}
 
 			if err == nil && tc.err != nil {
@@ -70,7 +70,7 @@ func TestResponceDelayUnmarshal(t *testing.T) {
 	}
 }
 
-func TestResponceDelayDelay(t *testing.T) {
+func TestResponseDelay(t *testing.T) {
 	testCases := map[string]struct {
 		delay ResponseDelay
 	}{


### PR DESCRIPTION
Now you can specify delay with "delay" field inside "response" section
(inside imposter). Delay value should be string that can be parsed by
time.ParseDuration or two such string concatenated by ":". For example
"1s" or "5s:10s". If you specified range, actual latency can be any
value within specified range.

Issue #32. 