### PR TITLE
Fix searching imposter files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Remove use of github.com/pkg/errors in favor to standard errors package
 * Remove backward compatibility with previous versions to go 1.13
 * Add `-watcher` flag to reload the server with any changes on `imposters` folder
+* Fix searching imposter files mechanism
 
 ## v0.3.3 (2019/05/11)
 

--- a/internal/server/http/imposter.go
+++ b/internal/server/http/imposter.go
@@ -44,7 +44,7 @@ func findImposters(impostersDirectory string, imposterFileCh chan string) error 
 		if err != nil {
 			return fmt.Errorf("%w: error finding imposters", err)
 		}
-		if !info.IsDir() && strings.LastIndex(info.Name(), imposterExtension) != -1 {
+		if !info.IsDir() && strings.HasSuffix(info.Name(), imposterExtension) {
 			imposterFileCh <- path
 		}
 		return nil


### PR DESCRIPTION
Previous implementation collected all file that have imposterExtension
in their name, for example "somefile.json.imp.swp".
Now for file to be collected its filename must end with
imposterExtension.