### PR TITLE
Improve the way to get version

### DIFF
--- a/internal/app/cmd/cmd.go
+++ b/internal/app/cmd/cmd.go
@@ -1,12 +1,15 @@
 package cmd
 
 import (
+	"log"
+	"os/exec"
+
 	"github.com/friendsofgo/killgrave/internal/app/cmd/http"
 	"github.com/spf13/cobra"
 )
 
 var (
-	_version = "dev"
+	_version = getVersion()
 )
 
 const (
@@ -33,4 +36,14 @@ func NewKillgraveCmd() *cobra.Command {
 	rootCmd.AddCommand(http.NewHTTPCmd())
 
 	return rootCmd
+}
+
+func getVersion() string {
+	versionBytes, err := exec.Command("git", "describe", "--always", "--dirty").Output()
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return string(versionBytes)
 }


### PR DESCRIPTION
This PR is for #66 

**What has been done**:
I have used exec package to get output of `git describe` command and assigned it to `_version`

**How to test**:
Compile from source or use go get
