### PR TITLE
Update Docker instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,11 +99,11 @@ If you are a mac user, you could install Killgrave using, [Homebrew](https://bre
 $ brew install friendsofgo/tap/killgrave
 ```
 
-:warning:  If you are using the hombrew way, you only get the [last Killgrave version](https://github.com/friendsofgo/killgrave/releases), we hope fix this soon.
+:warning:  If you are installing via homebrew, you only get the [last Killgrave version](https://github.com/friendsofgo/killgrave/releases), we hope fix this soon.
 
 ### Docker
 
-The application is also available through [Docker](https://hub.docker.com/r/friendsofgo/killgrave), just run:
+The application is also available through [Docker](https://hub.docker.com/r/friendsofgo/killgrave).
 
 ```bash
 docker run -it --rm -p 3000:3000 -v $PWD/:/home -w /home friendsofgo/killgrave -h 0.0.0.0
@@ -112,15 +112,12 @@ docker run -it --rm -p 3000:3000 -v $PWD/:/home -w /home friendsofgo/killgrave -
 `-p 3000:3000` [publishes](https://docs.docker.com/engine/reference/run/#expose-incoming-ports) port 3000 inside the
 container (where Killgrave is listening by default) to port 3000 on the host machine.
 
-`-h 0.0.0.0` is necessary to allow Killgrave to listen and respond to requests from outside the container (the default, `localhost`, will not capture requests from the host network).
-
-
+`-h 0.0.0.0` is necessary to allow Killgrave to listen and respond to requests from outside the container (the default,
+`localhost`, will not capture requests from the host network).
 
 ### Other
 
-If you are using, windows or linux you could get the binary for your arch on the release section:
-
-[https://github.com/friendsofgo/killgrave/releases](https://github.com/friendsofgo/killgrave/releases)
+Windows and Linux users can download binaries from the [Github Releases](https://github.com/friendsofgo/killgrave/releases) page.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,12 @@ The application is also available through [Docker](https://hub.docker.com/r/frie
 docker run -it --rm -p 3000:3000 -v $PWD/:/home -w /home friendsofgo/killgrave -h 0.0.0.0
 ```
 
+`-p 3000:3000` [publishes](https://docs.docker.com/engine/reference/run/#expose-incoming-ports) port 3000 inside the
+container (where Killgrave is listening by default) to port 3000 on the host machine.
+
 `-h 0.0.0.0` is necessary to allow Killgrave to listen and respond to requests from outside the container (the default, `localhost`, will not capture requests from the host network).
+
+
 
 ### Other
 

--- a/README.md
+++ b/README.md
@@ -106,11 +106,10 @@ $ brew install friendsofgo/tap/killgrave
 The application is also available through [Docker](https://hub.docker.com/r/friendsofgo/killgrave), just run:
 
 ```bash
-docker run -it --rm -p 3000:3000 -v $PWD/:/home -w /home friendsofgo/killgrave
+docker run -it --rm -p 3000:3000 -v $PWD/:/home -w /home friendsofgo/killgrave -h 0.0.0.0
 ```
-Remember to use the [-p](https://docs.docker.com/engine/reference/run/#expose-incoming-ports) flag to expose the container port where the application is listening (3000 by default).
 
-NOTE: If you want to use `killgrave` in Docker at the same time as using your own dockerised HTTP-based API please be careful with networking issues.
+`-h 0.0.0.0` is necessary to allow Killgrave to listen and respond to requests from outside the container (the default, `localhost`, will not capture requests from the host network).
 
 ### Other
 


### PR DESCRIPTION
Two changes:
1. Add `-h 0.0.0.0` to the Docker command in order for the instructions to actually work and respond to `curl`'s from the host machine. This is a project-specific sharp edge since Killgrave defaults to `localhost` and therefore will not work out of the box using the original command.
2. (I'm ok with reverting this) Remove vague warning about Docker networking and note about `-p` flag. IMO this is table-stakes Docker knowledge not well suited for a project-specific documentation (possibly belongs in a more fleshed out example). Put another way, why not also document the `-v` volume mount and the `-w` working directory change? Seems like none of it should be included here.