### PR TITLE
Enhancement: Create the imposter folder when the mock server is start…

### DIFF
--- a/internal/server/http/server.go
+++ b/internal/server/http/server.go
@@ -90,7 +90,14 @@ func (s *Server) Build() error {
 	}
 
 	if _, err := os.Stat(s.impostersPath); os.IsNotExist(err) {
-		return fmt.Errorf("%w: the directory %s doesn't exists", err, s.impostersPath)
+		// If imposter folder is not there create it.
+		dirName := s.impostersPath
+
+		err := os.Mkdir(dirName, 0755)
+		if err != nil {
+			fmt.Println(err)
+		}
+		log.Println("imposters directory created successfully.")
 	}
 	var impostersCh = make(chan []Imposter)
 	var done = make(chan struct{})

--- a/internal/server/http/server_test.go
+++ b/internal/server/http/server_test.go
@@ -2,7 +2,6 @@ package http
 
 import (
 	"crypto/tls"
-	"errors"
 	"io"
 	"io/ioutil"
 	"log"
@@ -31,7 +30,6 @@ func TestServer_Build(t *testing.T) {
 		server Server
 		err    error
 	}{
-		{"imposter directory not found", NewServer("failImposterPath", nil, &http.Server{}, &Proxy{}, false, imposterFs), errors.New("hello")},
 		{"malformatted json", NewServer("test/testdata/malformatted_imposters", nil, &http.Server{}, &Proxy{}, false, imposterFs), nil},
 		{"valid imposter", NewServer("test/testdata/imposters", mux.NewRouter(), &http.Server{}, &Proxy{}, false, imposterFs), nil},
 	}


### PR DESCRIPTION
**When we launch the mock server:**
**Earlier Behaviour:**
1) For the very first time and if the imposters folder doesn't exist,  it will give an error message and fail to launch.
![enhance](https://github.com/friendsofgo/killgrave/assets/56126385/bdf35fe1-556f-4850-9d5b-3b6a577a0a6c)
2) create a default imposter folder manually.

**New approach:** 
1) Even if the imposters folder doesn't exist at the very first time, create it on the fly.   