### PR TITLE
Fix watcher mode

### DIFF
--- a/internal/app/cmd/cmd.go
+++ b/internal/app/cmd/cmd.go
@@ -152,7 +152,7 @@ func runWatcher(cfg killgrave.Config, currentSrv *server.Server) (*watcher.Watch
 		if err := currentSrv.Shutdown(); err != nil {
 			log.Fatal(err)
 		}
-		runServer(cfg)
+		*currentSrv = runServer(cfg)
 	})
 	return w, nil
 }


### PR DESCRIPTION
The watcher mode (`-w`) is working only partially because once there's a change detected, it shut downs the existing server and initializes another one, but doesn't update the reference, so on the following updates, the newer server is not being shutdown, causing `bind: address already in use` error.

So, this PR basically ensures that the watcher callback updates the reference to the server with the new one on every "restart" (after every event detected by the watcher).

Fixes #148 