### PR TITLE
Remove no longer used badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,7 @@ Killgrave is a simulator for HTTP-based APIs, in simple words a **Mock Server**,
 ![Github actions](https://github.com/friendsofgo/killgrave/actions/workflows/main.yaml/badge.svg?branch=main)
 [![Version](https://img.shields.io/github/release/friendsofgo/killgrave.svg?style=flat-square)](https://github.com/friendsofgo/killgrave/releases/latest)
 [![Go Report Card](https://goreportcard.com/badge/github.com/friendsofgo/killgrave)](https://goreportcard.com/report/github.com/friendsofgo/killgrave)
-[![Total alerts](https://img.shields.io/lgtm/alerts/g/friendsofgo/killgrave.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/friendsofgo/killgrave/alerts/)
 [![FriendsOfGo](https://img.shields.io/badge/powered%20by-Friends%20of%20Go-73D7E2.svg)](https://friendsofgo.tech)
-
-<p>
-<a href="https://www.buymeacoffee.com/friendsofgo" target="_blank"><img src="https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png" alt="Buy Me A Coffee" style="height: auto !important;width: 100px !important;" ></a>
-</p>
 
 # Table of Content
 - [Overview](#overview)


### PR DESCRIPTION
It removes the no longer used badges:
- LGTM (now migrated to GitHub CodeQL scans)
- Buy me a coffee (account deleted)

Thanks!