### PR TITLE
feat: arm64/amd64 support for docker images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
@@ -53,5 +59,6 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,16 @@ FROM golang:1.21-alpine AS build
 
 LABEL MAINTAINER = 'Friends of Go (it@friendsofgo.tech)'
 
+ARG TARGETOS=linux
+ARG TARGETARCH=amd64
+
 RUN apk add --update git
 RUN apk add ca-certificates
 WORKDIR /go/src/github.com/friendsofgo/killgrave
 COPY . .
 RUN go mod tidy && TAG=$(git describe --tags --abbrev=0) \
     && LDFLAGS=$(echo "-s -w -X github.com/friendsofgo/killgrave/internal/app/cmd._version="docker-$TAG) \
-    && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -o /go/bin/killgrave -ldflags "$LDFLAGS" cmd/killgrave/main.go
+    && CGO_ENABLED=0 GOOS="${TARGETOS}" GOARCH="${TARGETARCH}" go build -a -installsuffix cgo -o /go/bin/killgrave -ldflags "$LDFLAGS" cmd/killgrave/main.go
 
 # Building image with the binary
 FROM scratch


### PR DESCRIPTION
Scope of this PR is to update github actions settings to build linux/arm64 and linux/amd64 docker images.


## References
- https://github.com/friendsofgo/killgrave/issues/162
- https://docs.docker.com/build/ci/github-actions/multi-platform/