### PR TITLE
Stop using deprecated package 'io/ioutil'

### DIFF
--- a/internal/config.go
+++ b/internal/config.go
@@ -3,7 +3,7 @@ package killgrave
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path"
 
@@ -146,7 +146,7 @@ func NewConfigFromFile(cfgPath string) (Config, error) {
 	defer configFile.Close()
 
 	var cfg Config
-	bytes, _ := ioutil.ReadAll(configFile)
+	bytes, _ := io.ReadAll(configFile)
 	if err := yaml.Unmarshal(bytes, &cfg); err != nil {
 		return Config{}, fmt.Errorf("%w: error while unmarshalling configFile file %s, using default configuration instead", err, cfgPath)
 	}

--- a/internal/server/http/handler.go
+++ b/internal/server/http/handler.go
@@ -1,7 +1,7 @@
 package http
 
 import (
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -49,7 +49,7 @@ func fetchBodyFromFile(bodyFile string) (bytes []byte) {
 
 	f, _ := os.Open(bodyFile)
 	defer f.Close()
-	bytes, err := ioutil.ReadAll(f)
+	bytes, err := io.ReadAll(f)
 	if err != nil {
 		log.Printf("imposible read the file %s: %v\n", bodyFile, err)
 	}

--- a/internal/server/http/handler_test.go
+++ b/internal/server/http/handler_test.go
@@ -2,7 +2,7 @@ package http
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -40,7 +40,7 @@ func TestImposterHandler(t *testing.T) {
 
 	f, _ := os.Open(bodyFile)
 	defer f.Close()
-	expectedBodyFileData, _ := ioutil.ReadAll(f)
+	expectedBodyFileData, _ := io.ReadAll(f)
 
 	var dataTest = []struct {
 		name         string

--- a/internal/server/http/route_matchers.go
+++ b/internal/server/http/route_matchers.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -37,7 +37,7 @@ func validateSchema(imposter Imposter, req *http.Request) error {
 
 	defer func() {
 		req.Body.Close()
-		req.Body = ioutil.NopCloser(bytes.NewBuffer(requestBodyBytes))
+		req.Body = io.NopCloser(bytes.NewBuffer(requestBodyBytes))
 	}()
 
 	schemaFile := imposter.CalculateFilePath(*imposter.Request.SchemaFile)
@@ -45,7 +45,7 @@ func validateSchema(imposter Imposter, req *http.Request) error {
 		return fmt.Errorf("%w: the schema file %s not found", err, schemaFile)
 	}
 
-	requestBodyBytes, err := ioutil.ReadAll(req.Body)
+	requestBodyBytes, err := io.ReadAll(req.Body)
 	if err != nil {
 		return fmt.Errorf("%w: impossible read the request body", err)
 	}
@@ -60,7 +60,7 @@ func validateSchema(imposter Imposter, req *http.Request) error {
 		return fmt.Errorf("%w: impossible find the schema", err)
 	}
 
-	schemaBytes, err := ioutil.ReadFile(schemaFilePath)
+	schemaBytes, err := os.ReadFile(schemaFilePath)
 	if err != nil {
 		return fmt.Errorf("%w: impossible read the schema", err)
 	}

--- a/internal/server/http/route_matchers_test.go
+++ b/internal/server/http/route_matchers_test.go
@@ -3,7 +3,7 @@ package http
 import (
 	"bytes"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -12,10 +12,10 @@ import (
 )
 
 func TestMatcherBySchema(t *testing.T) {
-	bodyA := ioutil.NopCloser(bytes.NewReader([]byte("{\"type\": \"gopher\"}")))
-	bodyB := ioutil.NopCloser(bytes.NewReader([]byte("{\"type\": \"cat\"}")))
-	emptyBody := ioutil.NopCloser(bytes.NewReader([]byte("")))
-	wrongBody := ioutil.NopCloser(errReader(0))
+	bodyA := io.NopCloser(bytes.NewReader([]byte("{\"type\": \"gopher\"}")))
+	bodyB := io.NopCloser(bytes.NewReader([]byte("{\"type\": \"cat\"}")))
+	emptyBody := io.NopCloser(bytes.NewReader([]byte("")))
+	wrongBody := io.NopCloser(errReader(0))
 
 	schemaGopherFile := "test/testdata/imposters/schemas/type_gopher.json"
 	schemaCatFile := "test/testdata/imposters/schemas/type_cat.json"

--- a/internal/watcher_test.go
+++ b/internal/watcher_test.go
@@ -2,7 +2,7 @@ package killgrave
 
 import (
 	"errors"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"testing"
@@ -13,7 +13,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	log.SetOutput(ioutil.Discard)
+	log.SetOutput(io.Discard)
 	os.Exit(m.Run())
 }
 


### PR DESCRIPTION
The `io/ioutil` package was deprecated since Go 1.16.