### PR TITLE
Add support for templating in response bodies

### DIFF
--- a/README.md
+++ b/README.md
@@ -617,6 +617,8 @@ Here is an example that includes query parameters gopherColor and gopherAge in t
 
 Templates can also include data from the request body, allowing you to create dynamic responses based on the request data. Currently only JSON bodies are supported. The request also needs to have the correct content type set (Content-Type: application/json).
 
+This example also showcases the functions `timeNow`, `timeUTC`, `timeAdd`, `timeFormat`, `jsonMarshal` and `stringsJoin` that are available for use in templates.
+
 Here is an example that includes the request body in the response:
 
 ````json
@@ -651,13 +653,17 @@ Here is an example that includes the request body in the response:
     "data": {
         "type": "{{ .RequestBody.data.type }}",
         "id": "{{ .PathParams.GopherID }}",
+        "timestamp": "{{ timeFormat (timeUTC (timeNow)) "2006-01-02 15:04" }}",
+        "birthday": "{{ timeFormat (timeAdd (timeNow) "24h") "2006-01-02" }}",
         "attributes": {
             "name": "{{ .RequestBody.data.attributes.name }}",
             "color": "{{ stringsJoin .QueryParams.gopherColor "," }}",
             "age": {{ index .QueryParams.gopherAge 0 }}
-        }
+        },
+        "friends": {{ jsonMarshal .RequestBody.data.friends }}
     }
 }
+
 ````
 ````json
 // request body to POST /gophers/bca49e8a-82dd-4c5d-b886-13a6ceb3744b?gopherColor=Blue&gopherColor=Purple&gopherAge=42
@@ -665,8 +671,15 @@ Here is an example that includes the request body in the response:
   "data": {
     "type": "gophers",
     "attributes": {
-    	"name": "Natalissa",
-    }
+      "name": "Natalissa"
+    },
+    "friends": [
+      {
+        "name": "Zebediah",
+        "color": "Purple",
+        "age": 55
+      }
+    ]
   }
 }
 // response
@@ -674,14 +687,28 @@ Here is an example that includes the request body in the response:
   "data": {
     "type": "gophers",
     "id": "bca49e8a-82dd-4c5d-b886-13a6ceb3744b",
+    "timestamp": "2006-01-02 15:04",
+    "birthday": "2006-01-03",
     "attributes": {
       "name": "Natalissa",
       "color": "Blue,Purple",
       "age": 42
-    }
+    },
+    "friends": [{"age":55,"color":"Purple","name":"Zebediah"}]
   }
 }
 ````
+
+#### Available custom templating functions
+
+These functions aren't part of the standard Go template functions, but are available for use in Killgrave templates:
+
+- `timeNow`: Returns the current time (in RFC3339 format).
+- `timeUTC`: Returns the current time in UTC (in RFC3339 format).
+- `timeAdd`: Adds a duration to a time.Time object. Uses the [Go ParseDuration format](https://pkg.go.dev/time#ParseDuration).
+- `timeFormat`: Formats a RFC3339 string using the provided layout. Uses the [Go time package layout](https://pkg.go.dev/time#pkg-constants).
+- `jsonMarshal`: Marshals an object to a JSON string.
+- `stringsJoin`: Concatenates an array of strings using a separator.
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -703,9 +703,9 @@ Here is an example that includes the request body in the response:
 
 These functions aren't part of the standard Go template functions, but are available for use in Killgrave templates:
 
-- `timeNow`: Returns the current time (in RFC3339 format).
-- `timeUTC`: Returns the current time in UTC (in RFC3339 format).
-- `timeAdd`: Adds a duration to a time.Time object. Uses the [Go ParseDuration format](https://pkg.go.dev/time#ParseDuration).
+- `timeNow`: Returns the current time. Returns RFC3339 formatted string.
+- `timeUTC`: Converts a RFC3339 formatted string to UTC. Returns RFC3339 formatted string.
+- `timeAdd`: Adds a duration to a RFC3339 formatted datetime string. Returns RFC3339 formatted string. Uses the [Go ParseDuration format](https://pkg.go.dev/time#ParseDuration).
 - `timeFormat`: Formats a RFC3339 string using the provided layout. Uses the [Go time package layout](https://pkg.go.dev/time#pkg-constants).
 - `jsonMarshal`: Marshals an object to a JSON string.
 - `stringsJoin`: Concatenates an array of strings using a separator.

--- a/README.md
+++ b/README.md
@@ -592,7 +592,7 @@ Since query parameters can be used more than once, they are stored in an array a
 
 Here is an example that includes query parameters gopherColor and gopherAge in the response, one of which can be used more than once:
 
-````json
+````jsonc
 // expects a request to, for example, GET /gophers/bca49e8a-82dd-4c5d-b886-13a6ceb3744b?gopherColor=Blue&gopherColor=Purple&gopherAge=42
 [
   {
@@ -621,7 +621,7 @@ This example also showcases the functions `timeNow`, `timeUTC`, `timeAdd`, `time
 
 Here is an example that includes the request body in the response:
 
-````json
+````jsonc
 // imposters/gophers.imp.json
 [
   {
@@ -665,7 +665,7 @@ Here is an example that includes the request body in the response:
 }
 
 ````
-````json
+````jsonc
 // request body to POST /gophers/bca49e8a-82dd-4c5d-b886-13a6ceb3744b?gopherColor=Blue&gopherColor=Purple&gopherAge=42
 {
   "data": {

--- a/README.md
+++ b/README.md
@@ -560,6 +560,129 @@ In the following example, we have defined multiple imposters for the `POST /goph
 ]
 ````
 
+#### Using Templating in Responses
+Killgrave supports templating in responses, allowing you to create dynamic responses based on request data. This feature uses Go's text/template package to render templates.
+
+In the following example, we define an imposter for the `GET /gophers/{id}` endpoint. The response body uses templating to include the id from the request URL.
+
+````json
+[
+  {
+    "request": {
+        "method": "GET",
+        "endpoint": "/gophers/{id}"
+    },
+    "response": {
+        "status": 200,
+        "headers": {
+            "Content-Type": "application/json"
+        },
+        "body": "{\"id\": \"{{.PathParams.id}}\", \"name\": \"Gopher\"}"
+    }
+  }
+]
+````
+In this example:
+
+- The endpoint field uses a path parameter {id}.
+- The body field in the response uses a template to include the id from the request URL.
+
+You can also use other parts of the request in your templates, such as headers and query parameters.
+Since query parameters can be used more than once, they are stored in an array and you can access them by index or use the `stringsJoin` function to concatenate them.
+
+Here is an example that includes a query parameter gopherColor in the response:
+
+````json
+[
+  {
+    "request": {
+        "method": "GET",
+        "endpoint": "/gophers/{id}",
+        "params": {
+            "gopherColor": "{v:[a-z]+}",
+            "age": "{v:[0-9]+}"
+        }
+    },
+    "response": {
+        "status": 200,
+        "headers": {
+            "Content-Type": "application/json"
+        },
+        "body": "{\"id\": \"{{ .PathParams.id }}\", \"color\": \"{{ stringsJoin .QueryParams.gopherColor "," }}\", \"age\": {{ index .QueryParams.age 0 }}}"
+    }
+  }
+]
+````
+
+Templates can also include data from the request, allowing you to create dynamic responses based on the request data. Currently only JSON bodies are supported. They also need to have the correct content type set.
+
+Here is an example that includes the request body in the response:
+
+````json
+// imposters/gophers.imp.json
+[
+  {
+    "request": {
+        "method": "POST",
+        "endpoint": "/gophers",
+        "schemaFile": "schemas/create_gopher_request.json",
+        "headers": {
+            "Content-Type": "application/json"
+        },
+        "params": {
+            "gopherColor": "{v:[a-z]+}",
+            "age": "{v:[0-9]+}"
+        }
+    },
+    "response": {
+        "status": 201,
+        "headers": {
+            "Content-Type": "application/json"
+        },
+        "bodyFile": "responses/create_gopher_response.json.tmpl"
+    }
+  }
+]
+````
+````tmpl
+// responses/create_gopher_response.json.tmpl
+{
+    "data": {
+        "type": "{{ .RequestBody.data.type }}",
+        "id": "{{ .PathParams.GopherID }}",
+        "attributes": {
+            "name": "{{ .RequestBody.data.attributes.name }}",
+            "color": "{{ stringsJoin .QueryParams.gopherColor "," }}",
+            "age": {{ index .QueryParams.age 0 }}
+        }
+    }
+}
+````
+````json
+// request body to POST /gophers/bca49e8a-82dd-4c5d-b886-13a6ceb3744b?gopherColor=Blue&gopherColor=Purple&age=42
+{
+  "data": {
+    "type": "gophers",
+    "attributes": {
+    	"name": "Natalissa",
+    }
+  }
+}
+// response
+{
+  "data": {
+    "type": "gophers",
+    "id": "bca49e8a-82dd-4c5d-b886-13a6ceb3744b",
+    "attributes": {
+      "name": "Natalissa",
+      "color": "Blue,Purple",
+      "age": 42
+    }
+  }
+}
+````
+
+
 ## Contributing
 [Contributions](CONTRIBUTING.md) are more than welcome, if you are interested please follow our guidelines to help you get started.
 

--- a/README.md
+++ b/README.md
@@ -590,7 +590,7 @@ In this example:
 You can also use other parts of the request in your templates, such query parameters and the request body.
 Since query parameters can be used more than once, they are stored in an array and you can access them by index or use the `stringsJoin` function to concatenate them.
 
-Here is an example that includes query parameters gopherColor and gopherAge in the response, one of which can be used more than once:
+Here is an example that includes query parameters `gopherColor` and `gopherAge` in the response, one of which can be used more than once:
 
 ````jsonc
 // expects a request to, for example, GET /gophers/bca49e8a-82dd-4c5d-b886-13a6ceb3744b?gopherColor=Blue&gopherColor=Purple&gopherAge=42

--- a/README.md
+++ b/README.md
@@ -561,7 +561,7 @@ In the following example, we have defined multiple imposters for the `POST /goph
 ````
 
 #### Using Templating in Responses
-Killgrave supports templating in responses, allowing you to create dynamic responses based on request data. This feature uses Go's text/template package to render templates.
+Killgrave supports templating in responses, allowing you to create dynamic responses based on request data. This feature uses Go's `text/template` package to render templates.
 
 In the following example, we define an imposter for the `GET /gophers/{id}` endpoint. The response body uses templating to include the id from the request URL.
 
@@ -587,12 +587,13 @@ In this example:
 - The endpoint field uses a path parameter {id}.
 - The body field in the response uses a template to include the id from the request URL.
 
-You can also use other parts of the request in your templates, such as headers and query parameters.
+You can also use other parts of the request in your templates, such query parameters and the request body.
 Since query parameters can be used more than once, they are stored in an array and you can access them by index or use the `stringsJoin` function to concatenate them.
 
-Here is an example that includes a query parameter gopherColor in the response:
+Here is an example that includes query parameters gopherColor and gopherAge in the response, one of which can be used more than once:
 
 ````json
+// expects a request to, for example, GET /gophers/bca49e8a-82dd-4c5d-b886-13a6ceb3744b?gopherColor=Blue&gopherColor=Purple&gopherAge=42
 [
   {
     "request": {
@@ -600,7 +601,7 @@ Here is an example that includes a query parameter gopherColor in the response:
         "endpoint": "/gophers/{id}",
         "params": {
             "gopherColor": "{v:[a-z]+}",
-            "age": "{v:[0-9]+}"
+            "gopherAge": "{v:[0-9]+}"
         }
     },
     "response": {
@@ -608,13 +609,13 @@ Here is an example that includes a query parameter gopherColor in the response:
         "headers": {
             "Content-Type": "application/json"
         },
-        "body": "{\"id\": \"{{ .PathParams.id }}\", \"color\": \"{{ stringsJoin .QueryParams.gopherColor "," }}\", \"age\": {{ index .QueryParams.age 0 }}}"
+        "body": "{\"id\": \"{{ .PathParams.id }}\", \"color\": \"{{ stringsJoin .QueryParams.gopherColor "," }}\", \"age\": {{ index .QueryParams.gopherAge 0 }}}"
     }
   }
 ]
 ````
 
-Templates can also include data from the request, allowing you to create dynamic responses based on the request data. Currently only JSON bodies are supported. They also need to have the correct content type set.
+Templates can also include data from the request body, allowing you to create dynamic responses based on the request data. Currently only JSON bodies are supported. The request also needs to have the correct content type set (Content-Type: application/json).
 
 Here is an example that includes the request body in the response:
 
@@ -631,7 +632,7 @@ Here is an example that includes the request body in the response:
         },
         "params": {
             "gopherColor": "{v:[a-z]+}",
-            "age": "{v:[0-9]+}"
+            "gopherAge": "{v:[0-9]+}"
         }
     },
     "response": {
@@ -653,13 +654,13 @@ Here is an example that includes the request body in the response:
         "attributes": {
             "name": "{{ .RequestBody.data.attributes.name }}",
             "color": "{{ stringsJoin .QueryParams.gopherColor "," }}",
-            "age": {{ index .QueryParams.age 0 }}
+            "age": {{ index .QueryParams.gopherAge 0 }}
         }
     }
 }
 ````
 ````json
-// request body to POST /gophers/bca49e8a-82dd-4c5d-b886-13a6ceb3744b?gopherColor=Blue&gopherColor=Purple&age=42
+// request body to POST /gophers/bca49e8a-82dd-4c5d-b886-13a6ceb3744b?gopherColor=Blue&gopherColor=Purple&gopherAge=42
 {
   "data": {
     "type": "gophers",

--- a/internal/server/http/handler.go
+++ b/internal/server/http/handler.go
@@ -1,12 +1,23 @@
 package http
 
 import (
+	"bytes"
+	"encoding/json"
+	"fmt"
 	"io"
 	"log"
 	"net/http"
 	"os"
+	"strings"
+	"text/template"
 	"time"
 )
+
+type TemplatingData struct {
+	RequestBody map[string]interface{}
+	PathParams  map[string]string
+	QueryParams map[string][]string
+}
 
 // ImposterHandler create specific handler for the received imposter
 func ImposterHandler(i Imposter) http.HandlerFunc {
@@ -17,7 +28,7 @@ func ImposterHandler(i Imposter) http.HandlerFunc {
 		}
 		writeHeaders(res, w)
 		w.WriteHeader(res.Status)
-		writeBody(i, res, w)
+		writeBody(i, res, w, r)
 	}
 }
 
@@ -31,14 +42,20 @@ func writeHeaders(r Response, w http.ResponseWriter) {
 	}
 }
 
-func writeBody(i Imposter, r Response, w http.ResponseWriter) {
-	wb := []byte(r.Body)
+func writeBody(i Imposter, res Response, w http.ResponseWriter, r *http.Request) {
+	bodyBytes := []byte(res.Body)
 
-	if r.BodyFile != nil {
-		bodyFile := i.CalculateFilePath(*r.BodyFile)
-		wb = fetchBodyFromFile(bodyFile)
+	if res.BodyFile != nil {
+		bodyFile := i.CalculateFilePath(*res.BodyFile)
+		bodyBytes = fetchBodyFromFile(bodyFile)
 	}
-	w.Write(wb)
+
+	templateBytes, err := applyTemplate(i, bodyBytes, r)
+	if err != nil {
+		log.Printf("error applying template: %v\n", err)
+	}
+
+	w.Write(templateBytes)
 }
 
 func fetchBodyFromFile(bodyFile string) (bytes []byte) {
@@ -54,4 +71,112 @@ func fetchBodyFromFile(bodyFile string) (bytes []byte) {
 		log.Printf("imposible read the file %s: %v\n", bodyFile, err)
 	}
 	return
+}
+
+func applyTemplate(i Imposter, bodyBytes []byte, r *http.Request) ([]byte, error) {
+	bodyStr := string(bodyBytes)
+
+	// check if the body contains a template
+	if !strings.Contains(bodyStr, "{{") {
+		return bodyBytes, nil
+	}
+
+	tmpl, err := template.New("body").
+		Funcs(template.FuncMap{"stringsJoin": strings.Join}).
+		Parse(bodyStr)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing template: %w", err)
+	}
+
+	extractedBody, err := extractBody(r)
+	if err != nil {
+		log.Printf("error extracting body: %v\n", err)
+	}
+
+	// parse request body in a generic way
+	tmplData := TemplatingData{
+		RequestBody: extractedBody,
+		PathParams:  extractPathParams(i, r),
+		QueryParams: extractQueryParams(r),
+	}
+
+	var tpl bytes.Buffer
+	err = tmpl.Execute(&tpl, tmplData)
+	if err != nil {
+		return nil, fmt.Errorf("error applying template: %w", err)
+	}
+
+	return tpl.Bytes(), nil
+}
+
+func extractBody(r *http.Request) (map[string]interface{}, error) {
+	body := make(map[string]interface{})
+	if r.Body == nil {
+		return body, nil
+	}
+
+	bodyBytes, err := io.ReadAll(r.Body)
+	if err != nil {
+		return body, fmt.Errorf("error reading request body: %w", err)
+	}
+
+	// Restore the body for further use
+	r.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+
+	contentType := r.Header.Get("Content-Type")
+
+	switch {
+	case strings.Contains(contentType, "application/json"):
+		err = json.Unmarshal(bodyBytes, &body)
+	default:
+		return body, fmt.Errorf("unsupported content type: %s", contentType)
+	}
+
+	if err != nil {
+		return body, fmt.Errorf("error unmarshaling request body: %w", err)
+	}
+
+	return body, nil
+}
+
+func extractPathParams(i Imposter, r *http.Request) map[string]string {
+	params := make(map[string]string)
+
+	path := r.URL.Path
+	if path == "" {
+		return params
+	}
+
+	endpoint := i.Request.Endpoint
+	// regex to split either path params using /:paramname or /{paramname}
+
+	// split path and endpoint by /
+	pathParts := strings.Split(path, "/")
+	imposterParts := strings.Split(endpoint, "/")
+
+	if len(pathParts) != len(imposterParts) {
+		log.Printf("request path and imposter endpoint parts do not match: %s, %s\n", path, endpoint)
+		return params
+	}
+
+	// iterate over pathParts and endpointParts
+	for i := range imposterParts {
+		if strings.HasPrefix(imposterParts[i], ":") {
+			params[imposterParts[i][1:]] = pathParts[i]
+		}
+		if strings.HasPrefix(imposterParts[i], "{") && strings.HasSuffix(imposterParts[i], "}") {
+			params[imposterParts[i][1:len(imposterParts[i])-1]] = pathParts[i]
+		}
+	}
+
+	return params
+}
+
+func extractQueryParams(r *http.Request) map[string][]string {
+	params := make(map[string][]string)
+	query := r.URL.Query()
+	for k, v := range query {
+		params[k] = v
+	}
+	return params
 }

--- a/internal/server/http/handler_test.go
+++ b/internal/server/http/handler_test.go
@@ -101,7 +101,8 @@ func TestImposterHandlerTemplating(t *testing.T) {
 		Headers:    &headers,
 	}
 
-	f, _ := os.Open(bodyFile)
+	f, err := os.Open(bodyFile)
+	require.NoError(t, err)
 	defer f.Close()
 
 	expectedBody := `{

--- a/internal/server/http/handler_test.go
+++ b/internal/server/http/handler_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -72,12 +73,19 @@ func TestImposterHandler(t *testing.T) {
 func TestImposterHandlerTemplating(t *testing.T) {
 	bodyRequest := []byte(`{
 		"data": {
-		  "type": "gophers",
-		  "attributes": {
-			"name": "Natalissa"
-		  }
+			"type": "gophers",
+			"attributes": {
+				"name": "Natalissa"
+			},
+			"friends": [
+				{
+					"name": "Zebediah",
+					"color": "Purple",
+					"age": 55
+				}
+			]
 		}
-	  }`)
+	}`)
 	var headers = make(map[string]string)
 	headers["Content-Type"] = "application/json"
 
@@ -100,11 +108,14 @@ func TestImposterHandlerTemplating(t *testing.T) {
     "data": {
         "type": "gophers",
         "id": "bca49e8a-82dd-4c5d-b886-13a6ceb3744b",
+        "timestamp": "` + time.Now().UTC().Format("2006-01-02 15:04") + `",
+        "birthday": "` + time.Now().UTC().Add(time.Hour*24).Format("2006-01-02") + `",
         "attributes": {
             "name": "Natalissa",
             "color": "Blue,Purple",
             "age": 42
-        }
+        },
+        "friends": [{"age":55,"color":"Purple","name":"Zebediah"}]
     }
 }
 `
@@ -127,6 +138,7 @@ func TestImposterHandlerTemplating(t *testing.T) {
 			req.Header.Set("Content-Type", "application/json")
 
 			rec := httptest.NewRecorder()
+			tt.imposter.PopulateBodyData()
 			handler := ImposterHandler(tt.imposter)
 
 			handler.ServeHTTP(rec, req)

--- a/internal/server/http/handler_test.go
+++ b/internal/server/http/handler_test.go
@@ -134,7 +134,7 @@ func TestImposterHandlerTemplating(t *testing.T) {
 	for _, tt := range dataTest {
 		t.Run(tt.name, func(t *testing.T) {
 			req, err := http.NewRequest("POST", "/gophers/bca49e8a-82dd-4c5d-b886-13a6ceb3744b?gopherColor=Blue&gopherColor=Purple&gopherAge=42", bytes.NewBuffer(bodyRequest))
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			req.Header.Set("Content-Type", "application/json")
 
 			rec := httptest.NewRecorder()

--- a/internal/server/http/test/testdata/imposters_templating/create_gopher.imp.json
+++ b/internal/server/http/test/testdata/imposters_templating/create_gopher.imp.json
@@ -1,0 +1,26 @@
+[
+    {
+        "request": {
+            "method": "POST",
+            "endpoint": "/gophers/{GopherID}",
+            "schemaFile": "schemas/create_gopher_request.json",
+            "headers": {
+                "Content-Type": "application/json"
+            },
+            "params": {
+                "gopherColor": "{v:[a-z]+}",
+                "gopherAge": "{v:[0-9]+}"
+            }
+        },
+        "response": {
+            "status": 200,
+            "headers": {
+                "Content-Type": "application/json"
+            },
+            "bodyFile": "responses/create_gopher_response.json.tmpl"
+        }
+    },
+    {
+        "t": "random_text"
+    }
+]

--- a/internal/server/http/test/testdata/imposters_templating/responses/create_gopher_response.json.tmpl
+++ b/internal/server/http/test/testdata/imposters_templating/responses/create_gopher_response.json.tmpl
@@ -2,10 +2,13 @@
     "data": {
         "type": "{{ .RequestBody.data.type }}",
         "id": "{{ .PathParams.GopherID }}",
+        "timestamp": "{{ timeFormat (timeUTC (timeNow)) "2006-01-02 15:04" }}",
+        "birthday": "{{ timeFormat (timeAdd (timeUTC (timeNow)) "24h") "2006-01-02" }}",
         "attributes": {
             "name": "{{ .RequestBody.data.attributes.name }}",
             "color": "{{ stringsJoin .QueryParams.gopherColor "," }}",
             "age": {{ index .QueryParams.gopherAge 0 }}
-        }
+        },
+        "friends": {{ jsonMarshal .RequestBody.data.friends }}
     }
 }

--- a/internal/server/http/test/testdata/imposters_templating/responses/create_gopher_response.json.tmpl
+++ b/internal/server/http/test/testdata/imposters_templating/responses/create_gopher_response.json.tmpl
@@ -1,0 +1,11 @@
+{
+    "data": {
+        "type": "{{ .RequestBody.data.type }}",
+        "id": "{{ .PathParams.GopherID }}",
+        "attributes": {
+            "name": "{{ .RequestBody.data.attributes.name }}",
+            "color": "{{ stringsJoin .QueryParams.gopherColor "," }}",
+            "age": {{ index .QueryParams.gopherAge 0 }}
+        }
+    }
+}

--- a/internal/server/http/test/testdata/imposters_templating/schemas/create_gopher_request.json
+++ b/internal/server/http/test/testdata/imposters_templating/schemas/create_gopher_request.json
@@ -1,0 +1,34 @@
+{
+    "type": "object",
+    "properties": {
+        "data": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "gophers"
+                    ]
+                },
+                "attributes": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "name"
+                    ]
+                }
+            },
+            "required": [
+                "type",
+                "attributes"
+            ]
+        }
+    },
+    "required": [
+        "data"
+    ]
+}

--- a/internal/templating/custom_functions.go
+++ b/internal/templating/custom_functions.go
@@ -1,0 +1,47 @@
+package templating
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+func JsonMarshal(v interface{}) (string, error) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+func TimeNow() string {
+	return time.Now().Format(time.RFC3339)
+}
+
+func TimeUTC(t string) (string, error) {
+	parsedTime, err := time.Parse(time.RFC3339, t)
+	if err != nil {
+		return "", fmt.Errorf("error parsing time: %v", err)
+	}
+	return parsedTime.UTC().Format(time.RFC3339), nil
+}
+
+func TimeAdd(t string, d string) (string, error) {
+	parsedTime, err := time.Parse(time.RFC3339, t)
+	if err != nil {
+		return "", fmt.Errorf("error parsing time: %v", err)
+	}
+	duration, err := time.ParseDuration(d)
+	if err != nil {
+		return "", fmt.Errorf("error parsing duration: %v", err)
+	}
+	return parsedTime.Add(duration).Format(time.RFC3339), nil
+}
+
+func TimeFormat(t string, layout string) (string, error) {
+	parsedTime, err := time.Parse(time.RFC3339, t)
+	if err != nil {
+		return "", fmt.Errorf("error parsing time: %v", err)
+	}
+	return parsedTime.Format(layout), nil
+}

--- a/internal/templating/custom_functions_test.go
+++ b/internal/templating/custom_functions_test.go
@@ -1,0 +1,182 @@
+package templating
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJsonMarshal(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    interface{}
+		expected string
+	}{
+		{
+			name:     "simple map",
+			input:    map[string]string{"key": "value"},
+			expected: `{"key":"value"}`,
+		},
+		{
+			name:     "nested map",
+			input:    map[string]interface{}{"key": map[string]string{"nestedKey": "nestedValue"}},
+			expected: `{"key":{"nestedKey":"nestedValue"}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := JsonMarshal(tt.input)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestJsonMarshal_Invalid(t *testing.T) {
+	input := make(chan int)
+	_, err := JsonMarshal(input)
+	assert.Error(t, err)
+}
+
+func TestTimeNow(t *testing.T) {
+	before := time.Now().Truncate(time.Second)
+	got := TimeNow()
+	after := time.Now().Truncate(time.Second)
+
+	parsedTime, err := time.Parse(time.RFC3339, got)
+	assert.NoError(t, err, "TimeNow() returned invalid time format")
+
+	assert.True(t, parsedTime.After(before) || parsedTime.Equal(before))
+	assert.True(t, parsedTime.Before(after) || parsedTime.Equal(after))
+}
+
+func TestTimeUTC(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "valid RFC3339 time",
+			input:    "2023-10-15T13:34:02Z",
+			expected: "2023-10-15T13:34:02Z",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := TimeUTC(tt.input)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestTimeUTC_Invalid(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		errMsg string
+	}{
+		{
+			name:   "invalid time format",
+			input:  "invalid-time",
+			errMsg: "parsing time",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := TimeUTC(tt.input)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.errMsg)
+		})
+	}
+}
+
+func TestTimeAdd(t *testing.T) {
+	tests := []struct {
+		name     string
+		time     string
+		duration string
+		expected string
+	}{
+		{
+			name:     "add 1 hour",
+			time:     "2023-10-15T13:34:02Z",
+			duration: "1h",
+			expected: "2023-10-15T14:34:02Z",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := TimeAdd(tt.time, tt.duration)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestTimeAdd_Invalid(t *testing.T) {
+	tests := []struct {
+		name     string
+		time     string
+		duration string
+		errMsg   string
+	}{
+		{
+			name:     "invalid time format",
+			time:     "invalid-time",
+			duration: "1h",
+			errMsg:   "parsing time",
+		},
+		{
+			name:     "invalid duration format",
+			time:     "2023-10-15T13:34:02Z",
+			duration: "invalid-duration",
+			errMsg:   "time: invalid duration",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := TimeAdd(tt.time, tt.duration)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.errMsg)
+		})
+	}
+}
+
+func TestTimeFormat(t *testing.T) {
+	tests := []struct {
+		name     string
+		time     string
+		layout   string
+		expected string
+	}{
+		{
+			name:     "valid time and layout",
+			time:     "2023-10-15T13:34:02Z",
+			layout:   "2006-01-02 15:04:05",
+			expected: "2023-10-15 13:34:02",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := TimeFormat(tt.time, tt.layout)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestTimeFormat_Invalid(t *testing.T) {
+	_, err := TimeFormat("invalid-time", "2006-01-02 15:04:05")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parsing time")
+}

--- a/internal/templating/templating.go
+++ b/internal/templating/templating.go
@@ -1,0 +1,38 @@
+package templating
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"text/template"
+)
+
+type TemplatingData struct {
+	RequestBody map[string]interface{}
+	PathParams  map[string]string
+	QueryParams map[string][]string
+}
+
+func ApplyTemplate(bodyStr string, templData TemplatingData) ([]byte, error) {
+	tmpl, err := template.New("body").
+		Funcs(template.FuncMap{
+			"stringsJoin": strings.Join,
+			"jsonMarshal": JsonMarshal,
+			"timeNow":     TimeNow,
+			"timeUTC":     TimeUTC,
+			"timeAdd":     TimeAdd,
+			"timeFormat":  TimeFormat,
+		}).
+		Parse(bodyStr)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing template: %w", err)
+	}
+
+	var tpl bytes.Buffer
+	err = tmpl.Execute(&tpl, templData)
+	if err != nil {
+		return nil, fmt.Errorf("error applying template: %w", err)
+	}
+
+	return tpl.Bytes(), nil
+}

--- a/internal/templating/templating_test.go
+++ b/internal/templating/templating_test.go
@@ -1,0 +1,114 @@
+package templating
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyTemplate(t *testing.T) {
+	now := time.Now()
+	tests := []struct {
+		name      string
+		bodyStr   string
+		templData TemplatingData
+		expected  string
+	}{
+		{
+			name:    "simple template",
+			bodyStr: `{"message": "Hello, {{ .PathParams.name }}!"}`,
+			templData: TemplatingData{
+				PathParams: map[string]string{
+					"name": "World",
+				},
+			},
+			expected: `{"message": "Hello, World!"}`,
+		},
+		{
+			name:    "template with JSON marshaling",
+			bodyStr: `{"data": {{ jsonMarshal .RequestBody.data }}}`,
+			templData: TemplatingData{
+				RequestBody: map[string]interface{}{
+					"data": map[string]string{
+						"key": "value",
+					},
+				},
+			},
+			expected: `{"data": {"key":"value"}}`,
+		},
+		{
+			name: "template with time functions",
+			bodyStr: `{
+				"timestamp": "{{ timeFormat (timeUTC (timeNow)) "2006-01-02 15:04" }}",
+				"future": "{{ timeFormat (timeAdd (timeUTC (timeNow)) "24h") "2006-01-02" }}"
+			}`,
+			templData: TemplatingData{
+				RequestBody: map[string]interface{}{},
+				PathParams:  map[string]string{},
+				QueryParams: map[string][]string{},
+			},
+			expected: `{
+				"timestamp": "` + now.UTC().Format("2006-01-02 15:04") + `",
+				"future": "` + now.Add(24*time.Hour).UTC().Format("2006-01-02") + `"
+			}`,
+		},
+		{
+			name:    "template with string join",
+			bodyStr: `{"colors": "{{ stringsJoin .QueryParams.colors "," }}"}`,
+			templData: TemplatingData{
+				QueryParams: map[string][]string{
+					"colors": {"red", "green", "blue"},
+				},
+			},
+			expected: `{"colors": "red,green,blue"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ApplyTemplate(tt.bodyStr, tt.templData)
+			require.NoError(t, err)
+			assert.JSONEq(t, tt.expected, string(got))
+		})
+	}
+}
+
+func TestApplyTemplate_Error(t *testing.T) {
+	tests := []struct {
+		name      string
+		bodyStr   string
+		templData TemplatingData
+		errMsg    string
+	}{
+		{
+			name:    "invalid template directive",
+			bodyStr: `{"message": "Hello, {{ .PathParams.name | invalidFunc }}`,
+			templData: TemplatingData{
+				PathParams: map[string]string{
+					"name": "World",
+				},
+			},
+			errMsg: "function \"invalidFunc\" not defined",
+		},
+		{
+			name:    "invalid template",
+			bodyStr: `{"message": "Hello, {{ .InvalidField }}`,
+			templData: TemplatingData{
+				PathParams: map[string]string{
+					"name": "World",
+				},
+			},
+			errMsg: "error applying template",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ApplyTemplate(tt.bodyStr, tt.templData)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.errMsg)
+		})
+	}
+}


### PR DESCRIPTION
I have added support for using `text/template` engine in the response body.

This change allows users to declare dynamic responses using templating from path parameters, query parameters and in a limited way the request body.

If a template response uses the request body, the request currently needs to be a JSON and contain the `"Content-Type": "application/json"` header.